### PR TITLE
Adds support for early exit based on error type

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name:                   Generate code coverage
         run: |
           cargo install cargo-tarpaulin
-          cargo tarpaulin --verbose --features "json" --workspace --timeout 300 --out Xml
+          cargo tarpaulin --verbose --features "jitter" --workspace --timeout 300 --out Xml
 
       - name:                   Upload to codecov.io
         uses:                   codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name:                       coverage
+    runs-on:                    ubuntu-latest
+
+    steps:
+      - name:                   Checkout repository
+        uses:                   actions/checkout@v2
+
+      - name:                   Generate code coverage
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --verbose --features "json" --workspace --timeout 300 --out Xml
+
+      - name:                   Upload to codecov.io
+        uses:                   codecov/codecov-action@v1
+        with:
+          token:                ${{secrets.CODECOV_TOKEN}} 
+          fail_ci_if_error:     true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.5.0 @ [#30](https://github.com/srijs/rust-tokio-retry/pull/30)
+
+- Adds `RetryError` type inspired by [`backoff Error`](https://docs.rs/backoff/latest/backoff/enum.Error.html) where user can define Errors as `Transient` and `Permanent` so it is possible to early exit a retry. 
+
 ## Version 0.4.0 @ [#29](https://github.com/srijs/rust-tokio-retry/pull/29)
 
 - Adds `Retry::spawn_notify` to notify a retry with the associated `Error` and current `Duration`, PR [#4](https://github.com/naomijub/tokio-retry/pull/4).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-retry2"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Julia Naomi <jnboeira@outlook.com>","Sam Rijs <srijs@airpost.net>"]
 description = "Extensible, asynchronous retry behaviours for futures/tokio"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Extensible, asynchronous retry behaviours for the ecosystem of [tokio](https://t
 
 [![crates](http://meritbadge.herokuapp.com/tokio-retry2)](https://crates.io/crates/tokio-retry2)
 [![dependency status](https://deps.rs/repo/github/naomijub/tokio-retry2/status.svg)](https://deps.rs/repo/github/namijub/tokio-retry)
+[![codecov](https://codecov.io/gh/naomijub/tokio-retry/branch/main/graph/badge.svg?token=4VMVTZTN8A)](https://codecov.io/gh/naomijub/tokio-retry)
 
 
 [Documentation](https://docs.rs/tokio-retry2)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-retry2 = { version = "0.4", features = ["jitter"] }
+tokio-retry2 = { version = "0.5", features = ["jitter"] }
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ tokio-retry2 = { version = "0.5", features = ["jitter"] }
 ## Examples
 
 ```rust
-use tokio_retry2::Retry;
+use tokio_retry2::{Retry, RetryError};
 use tokio_retry2::strategy::{ExponentialBackoff, jitter, MaxInterval};
 
 async fn action() -> Result<u64, ()> {
     // do some real-world stuff here...
-    Err(())
+    RetryError::to_transient(())
 }
 
 #[tokio::main]
@@ -48,12 +48,12 @@ async fn main() -> Result<(), ()> {
 Or, to retry with a notification function:
 
 ```rust
-use tokio_retry2::Retry;
+use tokio_retry2::{Retry, RetryError};
 use tokio_retry2::strategy::{ExponentialBackoff, jitter, MaxInterval};
 
 async fn action() -> Result<u64, std::io::Error> {
     // do some real-world stuff here...
-    Err(())
+    RetryError::to_permanent(()) // Early exits on this error
 }
 
 fn notify(err: &std::io::Error, duration: std::time::Duration) {

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,9 +1,10 @@
+use crate::error::Error as RetryError;
 use std::future::Future;
 
 /// An action can be run multiple times and produces a future.
 pub trait Action {
     /// The future that this action produces.
-    type Future: Future<Output = Result<Self::Item, Self::Error>>;
+    type Future: Future<Output = Result<Self::Item, RetryError<Self::Error>>>;
     /// The item that the future may resolve with.
     type Item;
     /// The error that the future may resolve with.
@@ -12,7 +13,7 @@ pub trait Action {
     fn run(&mut self) -> Self::Future;
 }
 
-impl<R, E, T: Future<Output = Result<R, E>>, F: FnMut() -> T> Action for F {
+impl<R, E, T: Future<Output = Result<R, RetryError<E>>>, F: FnMut() -> T> Action for F {
     type Item = R;
     type Error = E;
     type Future = T;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,195 @@
+use std::error;
+use std::fmt;
+
+use std::time::Duration;
+
+/// `Error` is the error value in an actions's retry result.
+///
+/// Based on the two possible values, the operation
+/// may be retried.
+pub enum Error<E> {
+    /// `Permanent` means that it's impossible to execute the operation
+    /// successfully. This error is an early return from the retry operation.
+    Permanent(E),
+
+    /// `Transient` means that the error is temporary. If the `retry_after` is `None`
+    /// the operation should be retried according to the defined strategy policy, else after
+    /// the specified duration. Useful for handling ratelimits like a HTTP 429 response.
+    Transient {
+        err: E,
+        retry_after: Option<Duration>,
+    },
+}
+
+impl<E> Error<E> {
+    // Creates an permanent error.
+    pub fn permanent(err: E) -> Self {
+        Error::Permanent(err)
+    }
+
+    // Creates a Result::Err container with an permanent error.
+    pub fn to_permanent<T>(err: E) -> Result<T, Self> {
+        Err(Error::Permanent(err))
+    }
+
+    // Creates an transient error which is retried according to the defined strategy
+    // policy.
+    pub fn transient(err: E) -> Self {
+        Error::Transient {
+            err,
+            retry_after: None,
+        }
+    }
+
+    // Creates a Result::Err container with an transient error which
+    // is retried according to the defined strategy policy.
+    pub fn to_transient<T>(err: E) -> Result<T, Self> {
+        Err(Error::Transient {
+            err,
+            retry_after: None,
+        })
+    }
+
+    /// Creates a Result::Err container with a transient error which
+    /// is retried after the specified duration.
+    /// Useful for handling ratelimits like a HTTP 429 response.
+    pub fn to_retry_after<T>(err: E, duration: Duration) -> Result<T, Self> {
+        Err(Error::Transient {
+            err,
+            retry_after: Some(duration),
+        })
+    }
+
+    /// Creates a transient error which is retried after the specified duration.
+    /// Useful for handling ratelimits like a HTTP 429 response.
+    pub fn retry_after(err: E, duration: Duration) -> Self {
+        Error::Transient {
+            err,
+            retry_after: Some(duration),
+        }
+    }
+}
+
+impl<E> fmt::Display for Error<E>
+where
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match *self {
+            Error::Permanent(ref err)
+            | Error::Transient {
+                ref err,
+                retry_after: _,
+            } => err.fmt(f),
+        }
+    }
+}
+
+impl<E> fmt::Debug for Error<E>
+where
+    E: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let (name, err) = match *self {
+            Error::Permanent(ref err) => ("Permanent", err as &dyn fmt::Debug),
+            Error::Transient {
+                ref err,
+                retry_after: _,
+            } => ("Transient", err as &dyn fmt::Debug),
+        };
+        f.debug_tuple(name).field(err).finish()
+    }
+}
+
+impl<E> error::Error for Error<E>
+where
+    E: error::Error,
+{
+    fn description(&self) -> &str {
+        match *self {
+            Error::Permanent(_) => "permanent error",
+            Error::Transient { .. } => "transient error",
+        }
+    }
+
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::Permanent(ref err)
+            | Error::Transient {
+                ref err,
+                retry_after: _,
+            } => err.source(),
+        }
+    }
+
+    fn cause(&self) -> Option<&dyn error::Error> {
+        self.source()
+    }
+}
+
+/// By default all errors are transient. Permanent errors can
+/// be constructed explicitly. This implementation is for making
+/// the question mark operator (?) and the `try!` macro to work.
+impl<E> From<E> for Error<E> {
+    fn from(err: E) -> Error<E> {
+        Error::Transient {
+            err,
+            retry_after: None,
+        }
+    }
+}
+
+impl<E> PartialEq for Error<E>
+where
+    E: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Error::Permanent(ref self_err), Error::Permanent(ref other_err)) => {
+                self_err == other_err
+            }
+            (
+                Error::Transient {
+                    err: self_err,
+                    retry_after: self_retry_after,
+                },
+                Error::Transient {
+                    err: other_err,
+                    retry_after: other_retry_after,
+                },
+            ) => self_err == other_err && self_retry_after == other_retry_after,
+            _ => false,
+        }
+    }
+}
+
+#[test]
+fn create_permanent_error() {
+    let e = Error::permanent("err");
+    assert_eq!(e, Error::Permanent("err"));
+}
+
+#[test]
+fn create_transient_error() {
+    let e = Error::transient("err");
+    assert_eq!(
+        e,
+        Error::Transient {
+            err: "err",
+            retry_after: None
+        }
+    );
+}
+
+#[test]
+fn create_transient_error_with_retry_after() {
+    let retry_after = Duration::from_secs(42);
+    let e = Error::retry_after("err", retry_after);
+    assert_eq!(
+        e,
+        Error::Transient {
+            err: "err",
+            retry_after: Some(retry_after),
+        }
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,23 +7,23 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-retry2 = "0.4"
+//! tokio-retry2 = "0.5"
 //! ```
 //!
 //! # Example
 //!
 //! ```rust,no_run
 
-//! use tokio_retry2::Retry;
+//! use tokio_retry2::{Retry, RetryError};
 //! use tokio_retry2::strategy::{ExponentialBackoff, MaxInterval};
 //!
-//! async fn action() -> Result<u64, ()> {
+//! async fn action() -> Result<u64, RetryError<()>> {
 //!     // do some real-world stuff here...
-//!     Err(())
+//!     RetryError::to_permanent(())
 //! }
 //!
 //! # #[tokio::main]
-//! # async fn main() -> Result<(), ()> {
+//! # async fn main() -> Result<(), RetryError<()>> {
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
 //!     .factor(1) // multiplication factor applied to deplay
 //!     .max_delay_millis(100) // set max delay between retries to 500ms
@@ -36,14 +36,50 @@
 //! # }
 //! ```
 //!
-//! # Features
+//! ## Error Handling
+//!
+//! One key difference between `tokio-retry2` and `tokio-retry` is the fact that `tokio-retry2`
+//! supports early exits from the retry loop based on your error type. This allows you to pattern match
+//! your errors and define if you want to continue retrying or not. The following functions are
+//! helper functions to deal with it:
+//!
+//! ```rust,no_run
+//! use tokio_retry2::{Retry, RetryError};
+//! use std::time::Duration;
+//!
+//! async fn action() -> Result<u64, RetryError<usize>> {
+//!     // do some real-world stuff here...
+//!     // get and error named `err`
+//! #   let err = std::io::ErrorKind::AddrInUse;
+//!     match err {
+//!         std::io::ErrorKind::NotFound => RetryError::to_permanent(1)?, // equivalent to return Err(RetryError::permanent(2))`;
+//!         std::io::ErrorKind::PermissionDenied => {
+//!             return Err(RetryError::permanent(2)); // equivalent to `RetryError::to_permanent(2)`
+//!         }
+//!         std::io::ErrorKind::ConnectionRefused => {
+//!             return Err(RetryError::transient(3)); // equivalent to `RetryError::to_transient(3)`
+//!         }
+//!         std::io::ErrorKind::ConnectionReset => {
+//!             return Err(RetryError::retry_after(4, Duration::from_millis(10)));
+//!             // equivalent to `RetryError::to_retry_after(4, Duration::from_millis(10))`
+//!         }
+//!         std::io::ErrorKind::ConnectionAborted =>
+//!             // equivalent to `RetryError::to_retry_after(5, Duration::from_millis(15))`
+//!             RetryError::to_retry_after(5, Duration::from_millis(15))?,
+//!         err => RetryError::to_transient(6)? // equivalent to `return Err(RetryError::transient(6))`
+//!     };
+//!     Ok(0)
+//! }
+//! ```
+//!
+//! ## Features
 //! `[jitter]``
 //!
 //! To use jitter, add this to your Cargo.toml
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-retry2 = { version = "0.4", features = ["jitter"] }
+//! tokio-retry2 = { version = "0.5", features = ["jitter"] }
 //! ```
 //!
 //! # Example
@@ -67,6 +103,7 @@
 
 mod action;
 mod condition;
+pub(crate) mod error;
 mod future;
 mod notify;
 /// Assorted retry strategies including fixed interval and exponential back-off.
@@ -74,4 +111,5 @@ pub mod strategy;
 
 pub use action::Action;
 pub use condition::Condition;
+pub use error::Error as RetryError;
 pub use future::{Retry, RetryIf};


### PR DESCRIPTION
# Error Handling

- Early exit is done with RetryError::Permanent;
- Continue with retry strategy is done with RetryError::Transient;
- Continue with retry strategy adding an extra duration is done with RetryError::Transient setting `retry_after` field;
One key difference between `tokio-retry2` and `tokio-retry` is the fact that `tokio-retry2` supports early exits from the retry loop based on your error type. This allows you to pattern match your errors and define if you want to continue retrying or not. The following functions are helper functions to deal with it:

```rust,no_run
use tokio_retry2::{Retry, RetryError};
use std::time::Duration;

async fn action() -> Result<u64, RetryError<usize>> {
    // do some real-world stuff here...
    // get and error named `err`
   let err = std::io::ErrorKind::AddrInUse;
    match err {
        std::io::ErrorKind::NotFound => RetryError::to_permanent(1)?, // equivalent to return Err(RetryError::permanent(2))`;
        std::io::ErrorKind::PermissionDenied => {
            return Err(RetryError::permanent(2)); // equivalent to `RetryError::to_permanent(2)`
        }
        std::io::ErrorKind::ConnectionRefused => {
            return Err(RetryError::transient(3)); // equivalent to `RetryError::to_transient(3)`
        }
        std::io::ErrorKind::ConnectionReset => {
            return Err(RetryError::retry_after(4, Duration::from_millis(10)));
            // equivalent to `RetryError::to_retry_after(4, Duration::from_millis(10))`
        }
        std::io::ErrorKind::ConnectionAborted =>
            // equivalent to `RetryError::to_retry_after(5, Duration::from_millis(15))`
            RetryError::to_retry_after(5, Duration::from_millis(15))?,
        err => RetryError::to_transient(6)? // equivalent to `return Err(RetryError::transient(6))`
    };
    Ok(0)
}
```