### PR TITLE
Adds Implicit conversions between Result and RetryResult.PartialEq su…

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name:                   Generate code coverage
         run: |
           cargo install cargo-tarpaulin
-          cargo tarpaulin --verbose --features "jitter" --workspace --timeout 300 --out Xml
+          cargo tarpaulin --verbose --all-features --workspace --timeout 300 --out Xml
 
       - name:                   Upload to codecov.io
         uses:                   codecov/codecov-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.5.2 @ [#7](https://github.com/naomijub/tokio-retry/pull/7)
+
+- Add implicit conversion from `Result<T, E>` to `RetryResult<T, E>` a type enabled by feature to handle implicit type conversions from `E` to `RetryError<E>::Transient`. Same for `Option<T>`.
+- Adds `PartialEq` between  `Result<T, RetryError<E>>` and `RetryResult<T, E>` for `T` and `E` bounded by `PartialEq`.
+- Cargo update.
+
 ## Version 0.5.1 @ [#6](https://github.com/naomijub/tokio-retry/pull/6)
 
 - Adds `MapErr` trait to `RetryError`, that facilitates handling `map_err` in `Result` types, transforming them into `Result<_, RetryError<_>>`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-retry2"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Julia Naomi <jnboeira@outlook.com>","Sam Rijs <srijs@airpost.net>"]
 description = "Extensible, asynchronous retry behaviours for futures/tokio"
 license = "MIT"
@@ -12,6 +12,7 @@ edition = "2021"
 
 [features]
 jitter = ["rand"]
+implicit_results = []
 
 [dependencies]
 rand = { version = "0.8.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ async fn action() -> Result<u64, std::io::Error> {
 }
 
 fn notify(err: &std::io::Error, duration: std::time::Duration) {
-    tracing::info!("Error {err:?} ocurred at {duration:?}");
+    tracing::info!("Error {err:?} occurred at {duration:?}");
 }
 
 #[tokio::main]


### PR DESCRIPTION
- Add implicit conversion from `Result<T, E>` to `RetryResult<T, E>` a type enabled by feature to handle implicit type conversions from `E` to `RetryError<E>::Transient`. Same for `Option<T>`.
- Adds `PartialEq` between  `Result<T, RetryError<E>>` and `RetryResult<T, E>` for `T` and `E` bounded by `PartialEq`.
- Cargo update.