### PR TITLE
v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Include feature `tracing` to inform when a `max_duration` or `max_delay` has been reached.
 - Fixed bug that `retry_after` duration was not overwriting the strategy duration.
+- `jitter` ranges between 50% and 150% of initial duration
 
 ## Version 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Include feature `tracing` to inform when a `max_duration` or `max_delay` has been reached.
 - Fixed bug that `retry_after` duration was not overwriting the strategy duration.
-- `jitter` ranges between 50% and 150% of initial duration
+- `jitter` ranges between 50% and 150% of initial duration.
+- Adds `jitter_range` for custom `map` jitter ranges.
 
 ## Version 0.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.5.5
+
+- Include feature `tracing` to inform when a `max_duration` or `max_delay` has been reached.
+- Fixed bug that `retry_after` duration was not overwriting the strategy duration.
+
 ## Version 0.5.4
 
 - Exports `MaxIntervalIterator` as standard `strategy` struct.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-retry2"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Julia Naomi <jnboeira@outlook.com>","Sam Rijs <srijs@airpost.net>"]
 description = "Extensible, asynchronous retry behaviours for futures/tokio"
 license = "MIT"
@@ -12,11 +12,13 @@ edition = "2021"
 
 [features]
 jitter = ["rand"]
+tracing = ["dep:tracing"]
 implicit_results = []
 
 [dependencies]
 rand = { version = "0.8.5", optional = true }
 tokio = { version = "1.40", features = ["time"] }
+tracing = { version = "0.1.40", optional = true }
 pin-project = "1.1.5"
 
 [dev-dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
 test:
 	cargo test --all-features
 
+typos:
+	typos
+
 clippy:
 	cargo clippy --all-features -- -W clippy::all -W clippy::nursery -D warnings
 
 fmt:
 	cargo fmt --all
 
-lint: fmt clippy
+lint: typos fmt clippy
 
-all: fmt clippy test
+all: typos fmt clippy test
 
 pedantic:
 	cargo clippy --all-features -- -W clippy::pedantic -D warnings

--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-retry2 = { version = "0.5", features = ["jitter"] }
+tokio-retry2 = { version = "0.5", features = ["jitter", "tracing"] }
 ```
+
+### Features:
+- `jitter`: adds jittery duration to the retry. Mechanism to avoid multiple systems retrying at the same time.
+- `tracing`: using `tracing` crate to indicate that a strategy has reached its `max_duration` or `max_delay`.
 
 ## Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,9 @@
 //! ```
 //!
 //! ## Features
-//! `[jitter]``
+//! `[jitter]`
+//! - `jitter` ranges between 50% and 150% of the strategy delay.
+//! - `jitter_range(min: f64, max: f64)` ranges between `min * Duration` and `max * Duration`.
 //!
 //! To use jitter, add this to your Cargo.toml
 //!
@@ -84,6 +86,8 @@
 //!
 //! # Example
 //!
+//! ## `jitter`
+//!
 //! ```rust,no_run
 //! use tokio_retry2::Retry;
 //! use tokio_retry2::strategy::{ExponentialBackoff, jitter, MaxInterval};
@@ -91,6 +95,18 @@
 //! let retry_strategy = ExponentialBackoff::from_millis(10)
 //!    .max_interval(10000) // set max interval to 10 seconds
 //!    .map(jitter) // add jitter to the retry interval
+//!    .take(3);    // limit to 3 retries
+//!````
+//!
+//! ## `jitter_range`
+//!
+//! ```rust,no_run
+//! use tokio_retry2::Retry;
+//! use tokio_retry2::strategy::{ExponentialBackoff, jitter_range, MaxInterval};
+//!
+//! let retry_strategy = ExponentialBackoff::from_millis(10)
+//!    .max_interval(10000) // set max interval to 10 seconds
+//!    .map(jitter_range(0.5, 1.2)) // add jitter ranging between 50% and 120% to the retry interval
 //!    .take(3);    // limit to 3 retries
 //!````
 //!

--- a/src/strategy/fixed_interval.rs
+++ b/src/strategy/fixed_interval.rs
@@ -30,11 +30,16 @@ impl Iterator for FixedInterval {
     }
 }
 
-#[test]
-fn returns_some_fixed() {
-    let mut s = FixedInterval::new(Duration::from_millis(123));
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    assert_eq!(s.next(), Some(Duration::from_millis(123)));
-    assert_eq!(s.next(), Some(Duration::from_millis(123)));
-    assert_eq!(s.next(), Some(Duration::from_millis(123)));
+    #[test]
+    fn returns_some_fixed() {
+        let mut s = FixedInterval::new(Duration::from_millis(123));
+
+        assert_eq!(s.next(), Some(Duration::from_millis(123)));
+        assert_eq!(s.next(), Some(Duration::from_millis(123)));
+        assert_eq!(s.next(), Some(Duration::from_millis(123)));
+    }
 }

--- a/src/strategy/jitter.rs
+++ b/src/strategy/jitter.rs
@@ -3,3 +3,16 @@ use tokio::time::Duration;
 pub fn jitter(duration: Duration) -> Duration {
     duration.mul_f64(rand::random::<f64>())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jitter() {
+        let jitter = jitter(Duration::from_millis(100));
+        assert!(jitter.as_millis() >= 50);
+        assert!(jitter.as_millis() <= 150);
+        assert!(jitter.as_millis() != 100);
+    }
+}

--- a/src/strategy/jitter.rs
+++ b/src/strategy/jitter.rs
@@ -1,7 +1,11 @@
 use tokio::time::Duration;
 
 pub fn jitter(duration: Duration) -> Duration {
-    duration.mul_f64(rand::random::<f64>())
+    duration.mul_f64(rand::random::<f64>() + 0.5)
+}
+
+pub fn jitter_range(min: f64, max: f64) -> impl Fn(Duration) -> Duration {
+    move |x| x.mul_f64(rand::random::<f64>() * (max - min) + min)
 }
 
 #[cfg(test)]
@@ -13,6 +17,24 @@ mod tests {
         let jitter = jitter(Duration::from_millis(100));
         assert!(jitter.as_millis() >= 50);
         assert!(jitter.as_millis() <= 150);
+        assert!(jitter.as_millis() != 100);
+    }
+
+    #[test]
+    fn test_jitter_range() {
+        let jitter = jitter_range(0.01, 0.1)(Duration::from_millis(100));
+        assert!(jitter.as_millis() >= 1);
+        assert!(jitter.as_millis() <= 10);
+        assert!(jitter.as_millis() != 100);
+
+        let jitter = jitter_range(0.1, 0.2)(Duration::from_millis(100));
+        assert!(jitter.as_millis() >= 10);
+        assert!(jitter.as_millis() <= 20);
+        assert!(jitter.as_millis() != 100);
+
+        let jitter = jitter_range(0.5, 0.6)(Duration::from_millis(100));
+        assert!(jitter.as_millis() >= 50);
+        assert!(jitter.as_millis() <= 60);
         assert!(jitter.as_millis() != 100);
     }
 }

--- a/src/strategy/max_interval.rs
+++ b/src/strategy/max_interval.rs
@@ -47,6 +47,9 @@ impl<I: Iterator<Item = Duration>> Iterator for MaxIntervalIterator<I> {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.start.elapsed() > self.max_duration {
+            #[cfg(feature = "tracing")]
+            tracing::warn!("`max_duration` reached, cancelling retry");
+
             None
         } else {
             self.iter.next()

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -11,4 +11,4 @@ pub use self::fixed_interval::FixedInterval;
 pub use self::max_interval::{MaxInterval, MaxIntervalIterator};
 
 #[cfg(feature = "jitter")]
-pub use self::jitter::jitter;
+pub use self::jitter::{jitter, jitter_range};


### PR DESCRIPTION
## Version 0.5.5

- Include feature `tracing` to inform when a `max_duration` or `max_delay` has been reached.
- Fixed bug that `retry_after` duration was not overwriting the strategy duration.
- `jitter` ranges between 50% and 150% of initial duration.
- Adds `jitter_range` for custom `map` jitter ranges.